### PR TITLE
Updated net-imap to resolve dependabot alert

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -158,7 +158,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     mutex_m (0.3.0)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -355,7 +355,6 @@ DEPENDENCIES
   rubocop-govuk
   sqlite3
   timecop
-
 
 BUNDLED WITH
    2.6.9


### PR DESCRIPTION
### What
Upgrade net-imap to version 0.6.4 or later

### Why
A man-in-the-middle attacker can cause Net::IMAP#starttls to return "successfully", without starting TLS.

Link to JIRA card (if applicable):
https://github.com/GovWifi/govwifi_two_factor_auth/security
