### PR TITLE
Update devise gem from 5.0.3 to 5.0.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
     connection_pool (3.0.2)
     crass (1.0.6)
     date (3.5.1)
-    devise (5.0.3)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 7.0)


### PR DESCRIPTION
### What

Update devise gem from 5.0.3 to 5.0.4

### Why

Security Alert

Link to JIRA card (if applicable):
N//a
